### PR TITLE
Better detection for Web Worker and Blob support

### DIFF
--- a/lib/bonobo.js
+++ b/lib/bonobo.js
@@ -18,7 +18,16 @@
 		var d = document, w = window;
 
 		_.support = (function() {
-			return 'Worker' in w && 'Blob' in w && ('webkitURL' in w || 'URL' in w);
+			if ('Worker' in w && 'Blob' in w && ('webkitURL' in w || 'URL' in w))
+				try {
+					var blob = new Blob(['test'], { type: 'text/plain' });
+					return true;
+				}
+				catch (e) {
+					return false;
+				}
+			else
+				return false;
 		})();
 
 		_.manage = (function() {


### PR DESCRIPTION
Simply polling for Worker and Blob in window object isn't enough.  You have to attempt to create a Blob object using its constructor to see if it fails.
